### PR TITLE
Develop

### DIFF
--- a/CS System Classes/AHandlerDictionary.cs
+++ b/CS System Classes/AHandlerDictionary.cs
@@ -147,7 +147,7 @@ namespace System.Collections.Generic
         public new virtual void Add(TKey key, TValue value) { base.Add(key, value); OnDictionaryChanged(); }
 
         /// <summary>
-        /// Removes all keys and values from the <see cref="AHandlerDictionary<TKey,TValue>"/>.
+        /// Removes all keys and values from the <see cref="AHandlerDictionary{TKey,TValue}"/>.
         /// </summary>
         public new virtual void Clear() { base.Clear(); OnDictionaryChanged(); }
 
@@ -156,7 +156,7 @@ namespace System.Collections.Generic
         /// </summary>
         /// <param name="key">The key of the element to remove.</param>
         /// <returns><c>true</c> if the element is successfully found and removed; otherwise, <c>false</c>.
-        /// This method returns <c>false</c> if <paramref name="key"/> is not found in the <see cref="AHandlerDictionary<TKey,TValue>"/>.
+        /// This method returns <c>false</c> if <paramref name="key"/> is not found in the <see cref="AHandlerDictionary{TKey,TValue}"/>.
         /// </returns>
         /// <exception cref="System.ArgumentNullException"><paramref name="key"/> is null.</exception>
         public new virtual bool Remove(TKey key) { if (base.Remove(key)) { OnDictionaryChanged(); return true; } else return false; }

--- a/s4pi Extras/DDSPanel/DDSPanel.cs
+++ b/s4pi Extras/DDSPanel/DDSPanel.cs
@@ -239,9 +239,13 @@ namespace System.Windows.Forms
         /// </summary>
         [ReadOnly(true), Description("The size of the current mask (or Size.Empty if no mask loaded).")]
         public Size MaskSize { get { return MaskLoaded ? ddsMask.Size : Size.Empty; } }
+
+        /// <summary>
+        /// Indicates the image is not a native DDS image.
+        /// </summary>
+        public bool IsShuffled { get; private set; }
         #endregion
 
-        public bool IsShuffled { get; private set; }
         #region Events
         /// <summary>
         /// Raised to indicate Fit value changed.

--- a/s4pi Extras/Extensions/Extensions.txt
+++ b/s4pi Extras/Extensions/Extensions.txt
@@ -206,7 +206,7 @@
 0xB7FF8F95  _XML   .xml
 0xB8444447  UNKN   .bnry
 0xB91E18DB  UNKN   .bnry
-0xB93A9915  UNKN   .bnry
+0xB93A9915  TMCT   .thumbcache
 0xB9881120  _XML   .xml
 0xBA7B60B8  _XML   .xml
 0xBA856C78  RLES   .rles

--- a/s4pi Wrappers/DWorldResource/DWorldResource.cs
+++ b/s4pi Wrappers/DWorldResource/DWorldResource.cs
@@ -335,7 +335,7 @@ namespace DWorldResource
 
             #region IEquatable<OMGSChunk> Members
             public bool Equals(OMGSChunk other) { return tag.Equals(other.tag) && omgsChunks.Equals(other.omgsChunks); }
-            public override bool Equals(TagLengthValue other) { return other is OMGSChunk != null && Equals(other as OMGSChunk); }
+            public override bool Equals(TagLengthValue other) { return other as OMGSChunk != null && Equals(other as OMGSChunk); }
             public override int GetHashCode() { return tag.GetHashCode() ^ omgsChunks.GetHashCode(); }
             #endregion
 
@@ -368,7 +368,7 @@ namespace DWorldResource
 
             #region IEquatable<OMGRChunk> Members
             public bool Equals(OMGRChunk other) { return tag.Equals(other.tag) && omgrChunks.Equals(other.omgrChunks); }
-            public override bool Equals(TagLengthValue other) { return other is OMGRChunk != null && Equals(other as OMGRChunk); }
+            public override bool Equals(TagLengthValue other) { return other as OMGRChunk != null && Equals(other as OMGRChunk); }
             public override int GetHashCode() { return tag.GetHashCode() ^ omgrChunks.GetHashCode(); }
             #endregion
 
@@ -451,7 +451,7 @@ namespace DWorldResource
 
             #region IEquatable<LOT_Chunk> Members
             public bool Equals(LOT_Chunk other) { return tag.Equals(other.tag) && lotChunks.Equals(other.lotChunks); }
-            public override bool Equals(TagLengthValue other) { return other is LOT_Chunk != null && Equals(other as LOT_Chunk); }
+            public override bool Equals(TagLengthValue other) { return other as LOT_Chunk != null && Equals(other as LOT_Chunk); }
             public override int GetHashCode() { return tag.GetHashCode() ^ lotChunks.GetHashCode(); }
             #endregion
 
@@ -512,7 +512,7 @@ namespace DWorldResource
 
             #region IEquatable<OBJ_Chunk> Members
             public bool Equals(OBJ_Chunk other) { return tag.Equals(other.tag) && objChunks.Equals(other.objChunks); }
-            public override bool Equals(TagLengthValue other) { return other is OBJ_Chunk != null && Equals(other as OBJ_Chunk); }
+            public override bool Equals(TagLengthValue other) { return other as OBJ_Chunk != null && Equals(other as OBJ_Chunk); }
             public override int GetHashCode() { return tag.GetHashCode() ^ objChunks.GetHashCode(); }
             #endregion
 

--- a/s4pi Wrappers/ThumbnailCacheTableResource/Properties/AssemblyInfo.cs
+++ b/s4pi Wrappers/ThumbnailCacheTableResource/Properties/AssemblyInfo.cs
@@ -1,0 +1,40 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Thumbnail Cache Resource wrapper")]
+[assembly: AssemblyDescription("Wrapper for Sims4 Thumbnail Cache resources.")]
+#if DEBUG
+[assembly: AssemblyConfiguration("[DEBUG]")]
+#else
+[assembly: AssemblyConfiguration("")]
+#endif
+[assembly: AssemblyCompany("Peter L Jones")]
+[assembly: AssemblyProduct("sims4tools")]
+[assembly: AssemblyCopyright("Copyright © 2017  Peter L Jones.  Released under GPL 3.  See gpl-3.0.txt")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("97cb15ac-088b-4f97-917b-f342c0ef4c61")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+//[assembly: AssemblyVersion("1.0.0.0")]
+//[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/s4pi Wrappers/ThumbnailCacheTableResource/ThumbnailCacheResource.cs
+++ b/s4pi Wrappers/ThumbnailCacheTableResource/ThumbnailCacheResource.cs
@@ -1,0 +1,1177 @@
+﻿/***************************************************************************
+ *  Copyright (C) 2017 by Peter L Jones                                    *
+ *  pljones@users.sf.net                                                   *
+ *                                                                         *
+ *  This file is part of the Sims 4 Package Interface (s4pi)               *
+ *                                                                         *
+ *  s4pi is free software: you can redistribute it and/or modify           *
+ *  it under the terms of the GNU General Public License as published by   *
+ *  the Free Software Foundation, either version 3 of the License, or      *
+ *  (at your option) any later version.                                    *
+ *                                                                         *
+ *  s4pi is distributed in the hope that it will be useful,                *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *  GNU General Public License for more details.                           *
+ *                                                                         *
+ *  You should have received a copy of the GNU General Public License      *
+ *  along with s4pi.  If not, see <http://www.gnu.org/licenses/>.          *
+ ***************************************************************************/
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml;
+using System.Linq;
+using s4pi.Interfaces;
+
+namespace ThumbnailCacheResource
+{
+    public class ThumbnailCacheResource : AResource
+    {
+        static bool checking = s4pi.Settings.Settings.Checking;
+        const Int32 recommendedApiVersion = 1;
+
+        #region Attributes
+        private UInt32 version;
+        private UInt64 nextInstanceValue;
+        private ThumnailList thumbnails;
+        #endregion
+
+        #region Constructors
+        /// <summary>
+        /// Create a new instance of the resource
+        /// </summary>
+        /// <param name="APIversion">Requested API version</param>
+        /// <param name="s">Data stream to use, or null to create from scratch</param>
+        public ThumbnailCacheResource(int APIversion, Stream s) : base(APIversion, s) { if (stream == null) { stream = UnParse(); dirty = true; } stream.Position = 0; Parse(stream); }
+        #endregion
+
+        #region Data I/O
+        void Parse(Stream s)
+        {
+            BinaryReader br = new BinaryReader(s);
+            version = br.ReadUInt32();
+            nextInstanceValue = br.ReadUInt64();
+            if (checking) if (version != 6)
+                    throw new InvalidDataException(String.Format("{0}: unsupported 'version'.  Read '0x{1:X8}', supported: '0x00000006'", this.GetType().Name, version));
+            thumbnails = new ThumnailList(OnResourceChanged, s);
+        }
+
+        protected override Stream UnParse()
+        {
+            MemoryStream ms = new MemoryStream();
+            BinaryWriter bw = new BinaryWriter(ms);
+
+            bw.Write(version);
+            bw.Write(nextInstanceValue);
+
+            if (thumbnails == null) thumbnails = new ThumnailList(OnResourceChanged);
+            thumbnails.UnParse(ms);
+
+            bw.Flush();
+            return ms;
+        }
+        #endregion
+
+        #region AApiVersionedFields
+        public override int RecommendedApiVersion { get { return recommendedApiVersion; } }
+        public override List<string> ContentFields { get { return GetContentFields(requestedApiVersion, this.GetType()); } }
+        #endregion
+
+        #region Sub-types
+        public enum ThumbnailType
+        {
+            OBJECT,
+            SIM,
+            SIM_BUST,
+            SIM_CAS_PRESET,
+            SIM_CAS_PART,
+            SIM_COMPLETE_HEAD,
+            SIM_FEATURED_OUTFIT,
+            SIM_FULLBODY,
+            SIM_PORTRAIT_CAS,
+            SIM_HOUSEHOLD,
+            FLOOR,
+            WALL,
+            MODEL,
+            AVATAR,
+            LOT_BLUEPRINT,
+            FENCE,
+            STAIR,
+            RAILING,
+            FLOORTRIM_FRIEZE,
+            ROOFTRIM,
+            LOT_PREVIEW,
+            MAGALOG,
+            MAGALOG_MASK,
+            MEMORY,
+            GALLERY,
+            PHOTOBOOTH_FAMILY,
+            SIM_TRAVEL,
+            MAGALOG_EXCHANGE,
+            ROOF_PATTERN,
+            CEILING_RAIL,
+            LOT_PAINT,
+            WORLDMAP_LOT,
+            SIM_GALLERY,
+            BUNDLE_PREVIEW,
+            SIM_MANNEQUIN_OUTFIT,
+            SIM_PORTRAIT,
+        }
+        private static ThumbnailType[] thumbnailTypeSim = {
+            ThumbnailType.SIM,
+            ThumbnailType.SIM_BUST,
+            ThumbnailType.SIM_CAS_PRESET,
+            ThumbnailType.SIM_CAS_PART,
+            ThumbnailType.SIM_COMPLETE_HEAD,
+            ThumbnailType.SIM_FEATURED_OUTFIT,
+            ThumbnailType.SIM_FULLBODY,
+            ThumbnailType.SIM_MANNEQUIN_OUTFIT,
+            ThumbnailType.SIM_PORTRAIT_CAS,
+            ThumbnailType.SIM_HOUSEHOLD,
+            ThumbnailType.PHOTOBOOTH_FAMILY,
+            ThumbnailType.SIM_TRAVEL,
+            ThumbnailType.SIM_GALLERY,
+            ThumbnailType.SIM_PORTRAIT
+                                                         };
+
+        public enum ThumbnailSize
+        {
+            SMALL,
+            MEDIUM,
+            LARGE,
+            EXTRALARGE,
+            ENORMOUS,
+            MAX
+        }
+
+        public class ThumbnailData : AHandlerElement, IEquatable<ThumbnailData>
+        {
+            #region Attributes
+            protected UInt32 serializationID;
+            #endregion
+
+            #region Constructors
+            public ThumbnailData(int apiVersion, EventHandler handler, UInt32 serializationID) : base(apiVersion, handler) { this.serializationID = serializationID; }
+            public ThumbnailData(int apiVersion, EventHandler handler, ThumbnailData basis) : this(apiVersion, handler, basis.serializationID) { }
+
+            public static ThumbnailData Factory(int APIversion, EventHandler handler, ThumbnailType type)
+            {
+                if (thumbnailTypeSim.Contains(type))
+                {
+                    return new ThumbnailData(APIversion, handler, 0);
+                }
+                else if (type.Equals(ThumbnailType.MODEL) || type.Equals(ThumbnailType.OBJECT))
+                {
+                    return new ThumbnailDataModelObject(APIversion, handler);
+                }
+                throw new InvalidOperationException(String.Format("No TableEntryData for ThumbnailType {0}.", type));
+            }
+            #endregion
+
+            #region Data I/O
+            public static ThumbnailData Factory(int APIversion, EventHandler handler, Stream s, ThumbnailType type)
+            {
+                UInt32 serializationID = new BinaryReader(s).ReadUInt32();
+                if (thumbnailTypeSim.Contains(type))
+                {
+                    if (serializationID.Equals(0x11111111))
+                    {
+                        return new ThumbnailDataSimCasPart(APIversion, handler, s);
+                    }
+                    else if (serializationID.Equals(0x00000001))
+                    {
+                        return new ThumbnailDataSim(APIversion, handler, s);
+                    }
+                    else if (serializationID.Equals(0x00000002))
+                    {
+                        return new ThumbnailSimHousehold(APIversion, handler, s);
+                    }
+                    return new ThumbnailData(APIversion, handler, serializationID);
+                }
+                else if (type.Equals(ThumbnailType.MODEL) || type.Equals(ThumbnailType.OBJECT))
+                {
+                    return new ThumbnailDataModelObject(APIversion, handler, s, serializationID);
+                }
+                throw new InvalidOperationException(String.Format("No TableEntryData for ThumbnailType {0}.", type));
+            }
+            public virtual void UnParse(Stream s)
+            {
+                new BinaryWriter(s).Write(serializationID);
+            }
+            #endregion
+
+            #region AHandlerElement Members
+            public override int RecommendedApiVersion { get { return recommendedApiVersion; } }
+            public override List<string> ContentFields { get { return GetContentFields(requestedApiVersion, this.GetType()); } }
+            #endregion
+
+            #region IEquatable<ModelData> Members
+
+            public virtual bool Equals(ThumbnailData other)
+            {
+                return this.serializationID.Equals(other.serializationID)
+                    ;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj as ThumbnailData != null ? this.Equals(obj as ThumbnailData) : false;
+            }
+
+            public override int GetHashCode()
+            {
+                return serializationID.GetHashCode()
+                    ;
+            }
+
+            #endregion
+
+            #region Content Fields
+            [MinimumVersion(1)]
+            [MaximumVersion(recommendedApiVersion)]
+            [ElementPriority(1)]
+            public UInt32 ThumbnailDataType { get { return serializationID; } set { if (serializationID != value) { serializationID = value; OnElementChanged(); } } }
+            #endregion
+
+            public string Value { get { return this.ValueBuilder; } }
+        }
+        public class ThumbnailDataSimCasPart : ThumbnailData, IEquatable<ThumbnailDataSimCasPart>
+        {
+            #region Attributes
+            private Byte gender;
+            #endregion
+
+            #region Constructors
+            public ThumbnailDataSimCasPart(int apiVersion, EventHandler handler) : base(apiVersion, handler, 0x11111111) { }
+            public ThumbnailDataSimCasPart(int apiVersion, EventHandler handler, ThumbnailDataSimCasPart basis) : this(apiVersion, handler, basis.gender) { }
+            public ThumbnailDataSimCasPart(int apiVersion, EventHandler handler, Byte gender) : this(apiVersion, handler) { this.gender = gender; }
+            internal ThumbnailDataSimCasPart(int apiVersion, EventHandler handler, Stream s) : this(apiVersion, handler) { this.Parse(s); }
+            #endregion
+
+            #region Data I/O
+            private void Parse(Stream s) { gender = new BinaryReader(s).ReadByte(); }
+            public override void UnParse(Stream s) { base.UnParse(s); new BinaryWriter(s).Write(gender); }
+            #endregion
+
+            #region AHandlerElement Members
+            public override int RecommendedApiVersion { get { return recommendedApiVersion; } }
+            public override List<string> ContentFields
+            {
+                get
+                {
+                    List<String> contentFields = GetContentFields(requestedApiVersion, this.GetType());
+                    contentFields.Remove("ThumbnailDataType");
+                    return contentFields;
+                }
+            }
+            #endregion
+
+            #region IEquatable<ThumbnailDataSimCasPart> Members
+
+            public bool Equals(ThumbnailDataSimCasPart other)
+            {
+                return base.Equals((ThumbnailData)other)
+                    && this.gender.Equals(other.gender)
+                    ;
+            }
+
+            public override bool Equals(ThumbnailData obj)
+            {
+                return obj as ThumbnailDataSimCasPart != null ? this.Equals(obj as ThumbnailDataSimCasPart) : false;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj as ThumbnailDataSimCasPart != null ? this.Equals(obj as ThumbnailDataSimCasPart) : false;
+            }
+
+            public override int GetHashCode()
+            {
+                return base.GetHashCode()
+                    ^ gender.GetHashCode()
+                    ;
+            }
+
+            #endregion
+
+            #region Content Fields
+            [MinimumVersion(1)]
+            [MaximumVersion(recommendedApiVersion)]
+            [ElementPriority(1)]
+            public Byte Gender { get { return gender; } set { if (gender != value) { gender = value; OnElementChanged(); } } }
+            #endregion
+        }
+        public class ThumbnailDataSim : ThumbnailData, IEquatable<ThumbnailDataSim>
+        {
+            #region Attributes
+            private UInt64 simID;
+            private UInt32 pose;
+            #endregion
+
+            #region Constructors
+            public ThumbnailDataSim(int apiVersion, EventHandler handler) : base(apiVersion, handler, 0x00000001) { }
+            public ThumbnailDataSim(int apiVersion, EventHandler handler, ThumbnailDataSim basis) : this(apiVersion, handler, basis.simID, basis.pose) { }
+            public ThumbnailDataSim(int apiVersion, EventHandler handler, UInt64 simID, UInt32 pose) : this(apiVersion, handler) { this.simID = simID; this.pose = pose; }
+            internal ThumbnailDataSim(int apiVersion, EventHandler handler, Stream s) : this(apiVersion, handler) { this.Parse(s); }
+            #endregion
+
+            #region Data I/O
+            private void Parse(Stream s) { BinaryReader r = new BinaryReader(s); simID = r.ReadUInt64(); pose = r.ReadUInt32(); }
+            public override void UnParse(Stream s) { base.UnParse(s); BinaryWriter w = new BinaryWriter(s); w.Write(simID); w.Write(pose); }
+            #endregion
+
+            #region AHandlerElement Members
+            public override int RecommendedApiVersion { get { return recommendedApiVersion; } }
+            public override List<string> ContentFields
+            {
+                get
+                {
+                    List<String> contentFields = GetContentFields(requestedApiVersion, this.GetType());
+                    contentFields.Remove("ThumbnailDataType");
+                    return contentFields;
+                }
+            }
+            #endregion
+
+            #region IEquatable<ThumbnailSimHousehold> Members
+
+            public bool Equals(ThumbnailDataSim other)
+            {
+                return base.Equals((ThumbnailData)other)
+                    && this.simID.Equals(other.simID)
+                    && this.pose.Equals(other.pose)
+                    ;
+            }
+
+            public override bool Equals(ThumbnailData obj)
+            {
+                return obj as ThumbnailDataSim != null ? this.Equals(obj as ThumbnailDataSim) : false;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj as ThumbnailDataSim != null ? this.Equals(obj as ThumbnailDataSim) : false;
+            }
+
+            public override int GetHashCode()
+            {
+                return base.GetHashCode()
+                    ^ simID.GetHashCode()
+                    ^ pose.GetHashCode()
+                    ;
+            }
+
+            #endregion
+
+            #region Content Fields
+            [MinimumVersion(1)]
+            [MaximumVersion(recommendedApiVersion)]
+            [ElementPriority(1)]
+            public UInt64 FamilyID { get { return simID; } set { if (simID != value) { simID = value; OnElementChanged(); } } }
+            [ElementPriority(2)]
+            public UInt32 Pose { get { return pose; } set { if (pose != value) { pose = value; OnElementChanged(); } } }
+            #endregion
+        }
+        public class ThumbnailSimHousehold : ThumbnailData, IEquatable<ThumbnailSimHousehold>
+        {
+            #region Attributes
+            private UInt64 familyID;
+            #endregion
+
+            #region Constructors
+            public ThumbnailSimHousehold(int apiVersion, EventHandler handler) : base(apiVersion, handler, 0x00000002) { }
+            public ThumbnailSimHousehold(int apiVersion, EventHandler handler, ThumbnailSimHousehold basis) : this(apiVersion, handler, basis.familyID) { }
+            public ThumbnailSimHousehold(int apiVersion, EventHandler handler, UInt64 familyID) : this(apiVersion, handler) { this.familyID = familyID; }
+            internal ThumbnailSimHousehold(int apiVersion, EventHandler handler, Stream s) : this(apiVersion, handler) { this.Parse(s); }
+            #endregion
+
+            #region Data I/O
+            private void Parse(Stream s) { familyID = new BinaryReader(s).ReadUInt64(); }
+            public override void UnParse(Stream s) { base.UnParse(s); new BinaryWriter(s).Write(familyID); }
+            #endregion
+
+            #region AHandlerElement Members
+            public override int RecommendedApiVersion { get { return recommendedApiVersion; } }
+            public override List<string> ContentFields
+            {
+                get
+                {
+                    List<String> contentFields = GetContentFields(requestedApiVersion, this.GetType());
+                    contentFields.Remove("ThumbnailDataType");
+                    return contentFields;
+                }
+            }
+            #endregion
+
+            #region IEquatable<ThumbnailSimHousehold> Members
+
+            public bool Equals(ThumbnailSimHousehold other)
+            {
+                return base.Equals((ThumbnailData)other)
+                    && this.familyID.Equals(other.familyID)
+                    ;
+            }
+
+            public override bool Equals(ThumbnailData obj)
+            {
+                return obj as ThumbnailSimHousehold != null ? this.Equals(obj as ThumbnailSimHousehold) : false;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj as ThumbnailSimHousehold != null ? this.Equals(obj as ThumbnailSimHousehold) : false;
+            }
+
+            public override int GetHashCode()
+            {
+                return base.GetHashCode()
+                    ^ familyID.GetHashCode()
+                    ;
+            }
+
+            #endregion
+
+            #region Content Fields
+            [MinimumVersion(1)]
+            [MaximumVersion(recommendedApiVersion)]
+            [ElementPriority(1)]
+            public UInt64 FamilyID { get { return familyID; } set { if (familyID != value) { familyID = value; OnElementChanged(); } } }
+            #endregion
+        }
+
+        public class ModelData : AHandlerElement, IEquatable<ModelData>
+        {
+            #region Attributes
+            private UInt64 modelKey;
+            private Quaternion position;
+            #endregion
+
+            #region Constructors
+            public ModelData(int apiVersion, EventHandler handler) : this(apiVersion, handler, 0, new Quaternion(apiVersion, handler)) { }
+            public ModelData(int apiVersion, EventHandler handler, ModelData basis) : this(apiVersion, handler, basis.modelKey, basis.position) { }
+            public ModelData(int apiVersion, EventHandler handler, UInt64 modelKey, Quaternion position)
+                : base(apiVersion, handler)
+            {
+                this.modelKey = modelKey;
+                this.position = position;
+            }
+            public ModelData(int apiVersion, EventHandler handler, Stream s) : this(apiVersion, handler) { this.Parse(s); }
+            #endregion
+
+            #region Data I/O
+            private void Parse(Stream s)
+            {
+                modelKey = new BinaryReader(s).ReadUInt64();
+                position = new Quaternion(requestedApiVersion, handler, s);
+            }
+            internal void UnParse(Stream s)
+            {
+                new BinaryWriter(s).Write(modelKey);
+                position.UnParse(s);
+            }
+            #endregion
+
+            #region AHandlerElement Members
+            public override int RecommendedApiVersion { get { return recommendedApiVersion; } }
+            public override List<string> ContentFields { get { return GetContentFields(requestedApiVersion, this.GetType()); } }
+            #endregion
+
+            #region IEquatable<ModelData> Members
+
+            public bool Equals(ModelData other)
+            {
+                return this.modelKey.Equals(other.modelKey)
+                    && this.position.Equals(other.position)
+                    ;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj as ModelData != null ? this.Equals(obj as ModelData) : false;
+            }
+
+            public override int GetHashCode()
+            {
+                return modelKey.GetHashCode()
+                    ^ position.GetHashCode()
+                    ;
+            }
+
+            #endregion
+
+            #region Content Fields
+            [MinimumVersion(1)]
+            [MaximumVersion(recommendedApiVersion)]
+            [ElementPriority(1)]
+            public UInt64 ModelKey { get { return modelKey; } set { if (modelKey != value) { modelKey = value; OnElementChanged(); } } }
+            [ElementPriority(2)]
+            public Quaternion Position { get { return position; } set { if (!position.Equals(value)) { position = value == null ? null : new Quaternion(requestedApiVersion, handler, value); OnElementChanged(); } } }
+            #endregion
+
+            public string Value { get { return ValueBuilder; } }
+        }
+        public class ModelDataList : DependentList<ModelData>
+        {
+            private UInt16 count;
+
+            #region Constructors
+            public ModelDataList(EventHandler handler) : base(handler, UInt16.MaxValue) { }
+            public ModelDataList(EventHandler handler, Stream s, UInt16 count) : this(handler) { this.count = count; this.elementHandler = handler; this.Parse(s); this.handler = handler; }
+            public ModelDataList(EventHandler handler, IEnumerable<ModelData> llp) : base(handler, llp, UInt16.MaxValue) { }
+            #endregion
+
+            #region Data I/O
+            protected override int ReadCount(Stream s) { return count; }
+            protected override void WriteCount(Stream s, int count) { }
+            protected override ModelData CreateElement(Stream s) { return new ModelData(0, elementHandler, s); }
+            protected override void WriteElement(Stream s, ModelData element) { element.UnParse(s); }
+            #endregion
+        }
+
+        [Flags]
+        public enum ModelInfoValueFlag : ulong
+        {
+            unknown17 = 0x00010000,
+            unknown18 = 0x00020000,
+            hasModelIndex19 = 0x00040000,
+            hasModelIndex20 = 0x00080000,
+            hasModelIndex21 = 0x00100000,
+            hasModelIndex22 = 0x00200000,
+            unknown23 = 0x004000000,
+            unknown24 = 0x008000000,
+            hasPaintingGroup25 = 0x01000000,
+            hasMaterialState26 = 0x02000000,
+            unknown27 = 0x04000000,
+            unknown28 = 0x08000000,
+            unknown29 = 0x10000000,
+            unknown30 = 0x20000000,
+            hasGeoState31 = 0x40000000,
+            hasPaintingKey32 = 0x80000000,
+        }
+
+        public abstract class ModelInfoValue : AHandlerElement, IEquatable<ModelInfoValue>
+        {
+            public ModelInfoValue(int apiVersion, EventHandler handler) : base(apiVersion, handler) { }
+
+            #region IEquatable<ModelData> Members
+
+            public virtual bool Equals(ModelInfoValue other)
+            {
+                return true
+                    ;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj as ModelInfoValue != null ? this.Equals(obj as ModelInfoValue) : false;
+            }
+
+            public override int GetHashCode()
+            {
+                return 0.GetHashCode()
+                    ;
+            }
+
+            #endregion
+
+            public abstract void UnParse(Stream s);
+
+            public string Value { get { return ValueBuilder; } }
+        }
+        public class ModelInfoValueByte : ModelInfoValue, IEquatable<ModelInfoValueByte>
+        {
+            #region Attributes
+            private Byte data;
+            #endregion
+
+            #region Constructors
+            public ModelInfoValueByte(int apiVersion, EventHandler handler) : base(apiVersion, handler) { }
+            public ModelInfoValueByte(int apiVersion, EventHandler handler, ModelInfoValueByte basis) : this(apiVersion, handler, basis.data) { }
+            public ModelInfoValueByte(int apiVersion, EventHandler handler, Byte data) : this(apiVersion, handler) { this.data = data; }
+            public ModelInfoValueByte(int apiVersion, EventHandler handler, Stream s) : this(apiVersion, handler) { this.Parse(s); }
+            static public implicit operator ModelInfoValueByte(ModelInfoValueUInt32 value) { return new ModelInfoValueByte(0, null, (Byte)(value.Data & 0xFF)); }
+            static public implicit operator ModelInfoValueByte(ModelInfoValueUInt64 value) { return new ModelInfoValueByte(0, null, (Byte)(value.Data & 0xFF)); ; }
+            #endregion
+
+            #region Data I/O
+            private void Parse(Stream s) { BinaryReader r = new BinaryReader(s); data = r.ReadByte(); }
+            public override void UnParse(Stream s) { BinaryWriter w = new BinaryWriter(s); w.Write(data); }
+            #endregion
+
+            #region AHandlerElement Members
+            public override int RecommendedApiVersion { get { return recommendedApiVersion; } }
+            public override List<string> ContentFields { get { return GetContentFields(requestedApiVersion, this.GetType()); } }
+            #endregion
+
+            #region IEquatable<ModelInfoValueByte> Members
+
+            public bool Equals(ModelInfoValueByte other)
+            {
+                return base.Equals((ModelInfoValue)other)
+                    && this.data.Equals(other.data)
+                    ;
+            }
+
+            public override bool Equals(ModelInfoValue obj)
+            {
+                return obj as ModelInfoValueByte != null ? this.Equals(obj as ModelInfoValueByte) : false;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj as ModelInfoValueByte != null ? this.Equals(obj as ModelInfoValueByte) : false;
+            }
+
+            public override int GetHashCode()
+            {
+                return base.GetHashCode()
+                    ^ data.GetHashCode()
+                    ;
+            }
+
+            #endregion
+
+            #region Content Fields
+            [MinimumVersion(1)]
+            [MaximumVersion(recommendedApiVersion)]
+            [ElementPriority(1)]
+            public Byte Data { get { return data; } set { if (data != value) { data = value; OnElementChanged(); } } }
+            #endregion
+        }
+        public class ModelInfoValueUInt32 : ModelInfoValue, IEquatable<ModelInfoValueUInt32>
+        {
+            #region Attributes
+            private UInt32 data;
+            #endregion
+
+            #region Constructors
+            public ModelInfoValueUInt32(int apiVersion, EventHandler handler) : base(apiVersion, handler) { }
+            public ModelInfoValueUInt32(int apiVersion, EventHandler handler, ModelInfoValueUInt32 basis) : this(apiVersion, handler, basis.data) { }
+            public ModelInfoValueUInt32(int apiVersion, EventHandler handler, UInt32 data) : this(apiVersion, handler) { this.data = data; }
+            public ModelInfoValueUInt32(int apiVersion, EventHandler handler, Stream s) : this(apiVersion, handler) { this.Parse(s); }
+            static public implicit operator ModelInfoValueUInt32(ModelInfoValueByte value) { return new ModelInfoValueUInt32(0, null, (UInt32)(value.Data & 0xFFFFFFFF)); }
+            static public implicit operator ModelInfoValueUInt32(ModelInfoValueUInt64 value) { return new ModelInfoValueUInt32(0, null, (UInt32)(value.Data & 0xFFFFFFFF)); }
+            #endregion
+
+            #region Data I/O
+            private void Parse(Stream s) { BinaryReader r = new BinaryReader(s); data = r.ReadUInt32(); }
+            public override void UnParse(Stream s) { BinaryWriter w = new BinaryWriter(s); w.Write(data); }
+            #endregion
+
+            #region AHandlerElement Members
+            public override int RecommendedApiVersion { get { return recommendedApiVersion; } }
+            public override List<string> ContentFields { get { return GetContentFields(requestedApiVersion, this.GetType()); } }
+            #endregion
+
+            #region IEquatable<ModelInfoValueUInt32> Members
+
+            public bool Equals(ModelInfoValueUInt32 other)
+            {
+                return base.Equals((ModelInfoValue)other)
+                    && this.data.Equals(other.data)
+                    ;
+            }
+
+            public override bool Equals(ModelInfoValue obj)
+            {
+                return obj as ModelInfoValueUInt32 != null ? this.Equals(obj as ModelInfoValueUInt32) : false;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj as ModelInfoValueUInt32 != null ? this.Equals(obj as ModelInfoValueUInt32) : false;
+            }
+
+            public override int GetHashCode()
+            {
+                return base.GetHashCode()
+                    ^ data.GetHashCode()
+                    ;
+            }
+
+            #endregion
+
+            #region Content Fields
+            [MinimumVersion(1)]
+            [MaximumVersion(recommendedApiVersion)]
+            [ElementPriority(1)]
+            public UInt32 Data { get { return data; } set { if (data != value) { data = value; OnElementChanged(); } } }
+            #endregion
+        }
+        public class ModelInfoValueUInt64 : ModelInfoValue, IEquatable<ModelInfoValueUInt64>
+        {
+            #region Attributes
+            private UInt64 data;
+            #endregion
+
+            #region Constructors
+            public ModelInfoValueUInt64(int apiVersion, EventHandler handler) : base(apiVersion, handler) { }
+            public ModelInfoValueUInt64(int apiVersion, EventHandler handler, ModelInfoValueUInt64 basis) : this(apiVersion, handler, basis.data) { }
+            public ModelInfoValueUInt64(int apiVersion, EventHandler handler, UInt64 data) : this(apiVersion, handler) { this.data = data; }
+            public ModelInfoValueUInt64(int apiVersion, EventHandler handler, Stream s) : this(apiVersion, handler) { this.Parse(s); }
+            static public implicit operator ModelInfoValueUInt64(ModelInfoValueByte value) { return new ModelInfoValueUInt64(0, null, (UInt64)(value.Data)); }
+            static public implicit operator ModelInfoValueUInt64(ModelInfoValueUInt32 value) { return new ModelInfoValueUInt64(0, null, (UInt64)(value.Data)); }
+            #endregion
+
+            #region Data I/O
+            private void Parse(Stream s) { BinaryReader r = new BinaryReader(s); data = r.ReadUInt64(); }
+            public override void UnParse(Stream s) { BinaryWriter w = new BinaryWriter(s); w.Write(data); }
+            #endregion
+
+            #region AHandlerElement Members
+            public override int RecommendedApiVersion { get { return recommendedApiVersion; } }
+            public override List<string> ContentFields { get { return GetContentFields(requestedApiVersion, this.GetType()); } }
+            #endregion
+
+            #region IEquatable<ModelInfoValueUInt32> Members
+
+            public bool Equals(ModelInfoValueUInt64 other)
+            {
+                return base.Equals((ModelInfoValue)other)
+                    && this.data.Equals(other.data)
+                    ;
+            }
+
+            public override bool Equals(ModelInfoValue obj)
+            {
+                return obj as ModelInfoValueUInt64 != null ? this.Equals(obj as ModelInfoValueUInt64) : false;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj as ModelInfoValueUInt64 != null ? this.Equals(obj as ModelInfoValueUInt64) : false;
+            }
+
+            public override int GetHashCode()
+            {
+                return base.GetHashCode()
+                    ^ data.GetHashCode()
+                    ;
+            }
+
+            #endregion
+
+            #region Content Fields
+            [MinimumVersion(1)]
+            [MaximumVersion(recommendedApiVersion)]
+            [ElementPriority(1)]
+            public UInt64 Data { get { return data; } set { if (data != value) { data = value; OnElementChanged(); } } }
+            #endregion
+        }
+        public class ModelInfoDict : DependentDictionary<ModelInfoValueFlag, ModelInfoValue>
+        {
+            #region Constructors
+            public ModelInfoDict(EventHandler handler) : base(handler) { }
+            public ModelInfoDict(EventHandler handler, Stream s) : this(null) { throw new NotImplementedException(); }
+            public ModelInfoDict(EventHandler handler, IDictionary<ModelInfoValueFlag, ModelInfoValue> dictionary) : this(null) { elementHandler = handler; this.AddRange(dictionary); this.handler = handler; }
+            #endregion
+
+            #region Data I/O
+            protected override void Parse(Stream s) { throw new NotImplementedException(); }
+            public override void UnParse(Stream s) { throw new NotImplementedException(); }
+            protected override Int32 ReadCount(Stream s) { throw new NotImplementedException(); }
+            protected override void WriteCount(Stream s, Int32 count) { throw new NotImplementedException(); }
+            protected override ModelInfoValueFlag CreateKey(Stream s) { throw new NotImplementedException(); }
+            protected override ModelInfoValue CreateValue(Stream s) { throw new NotImplementedException(); }
+            protected override void WriteKey(Stream s, ModelInfoValueFlag key) { throw new NotImplementedException(); }
+            protected override void WriteValue(Stream s, ModelInfoValue value) { throw new NotImplementedException(); }
+            #endregion
+
+            public ModelInfoValueFlag Flags
+            {
+                get
+                {
+                    UInt32 res = 0x00000000;
+                    foreach (var key in this.Keys)
+                        res &= (UInt32)key;
+                    return (ModelInfoValueFlag)res;
+                }
+            }
+
+            public override ModelInfoValue this[ModelInfoValueFlag key]
+            {
+                get
+                {
+                    return base[key];
+                }
+                set
+                {
+                    switch ((UInt32)key)
+                    {
+                        case 0x01000000: //ModelInfoValueFlags.hasPaintingGroup25
+                            base[key] = new ModelInfoValueUInt32(recommendedApiVersion, handler, (ModelInfoValueUInt32)value);
+                            break;
+                        case 0x02000000: //ModelInfoValueFlags.hasMaterialState26
+                            base[key] = new ModelInfoValueUInt32(recommendedApiVersion, handler, (ModelInfoValueUInt32)value);
+                            break;
+                        case 0x40000000: //ModelInfoValueFlags.hasGeoState31
+                            base[key] = new ModelInfoValueUInt32(recommendedApiVersion, handler, (ModelInfoValueUInt32)value);
+                            break;
+                        case 0x80000000: //ModelInfoValueFlags.hasPaintingKey32
+                            base[key] = new ModelInfoValueUInt64(recommendedApiVersion, handler, (ModelInfoValueUInt64)value);
+                            break;
+                        default:
+                            if (((UInt32)key & 0x003C0000) != 0) //ModelInfoValueFlags.hasModelIndex19-22 - but only one can have a value, setting enforces this
+                            {
+                                // Remove any existing hasModelIndex (other than that under 'key')
+                                for (var i = (UInt32)ModelInfoValueFlag.hasModelIndex19; !base.ContainsKey(key) && ((UInt32)Flags & 0x003C0000) != 0; i <<= 1)
+                                    this.Remove((ModelInfoValueFlag)i);
+                                base[key] = new ModelInfoValueByte(recommendedApiVersion, handler, (ModelInfoValueByte)value);
+                                break;
+                            }
+                            else
+                                throw new ArgumentException(String.Format("Unsupported ModelInfoValueFlag {0}", key));
+                    }
+                }
+            }
+        }
+
+        public class ThumbnailDataModelObject : ThumbnailData, IEquatable<ThumbnailDataModelObject>
+        {
+            #region Attributes
+            private ModelInfoValueFlag flags;
+            private ModelDataList data;
+            private ModelInfoDict info;
+            #endregion
+
+            #region Constructors
+            public ThumbnailDataModelObject(int apiVersion, EventHandler handler)
+                : this(apiVersion, handler,
+                0, new ModelDataList(null), new ModelInfoDict(null)) { }
+            public ThumbnailDataModelObject(int apiVersion, EventHandler handler, ThumbnailDataModelObject basis)
+                : this(apiVersion, handler,
+                basis.flags, basis.data, basis.info) { }
+            public ThumbnailDataModelObject(int apiVersion, EventHandler handler,
+                ModelInfoValueFlag flags, IEnumerable<ModelData> data, IDictionary<ModelInfoValueFlag, ModelInfoValue> info)
+                : base(apiVersion, handler, 0)
+            {
+                this.flags = flags;
+                this.data = new ModelDataList(handler, data);
+                this.info = new ModelInfoDict(handler, info);
+
+                // It is not that simple, however.  flags and info need to be consistent.
+
+                // First, sort out hasModelIndex...  This is even more complicated because multiple bits indicate "yes, that value should be there".
+                // Just having the value does not tell us which bit, though.  So I picked hasModelIndex19.
+                ModelInfoValueFlag flagsHasModelIndex = flags & (ModelInfoValueFlag)~(UInt32)0x003C0000; // what did we get told in 'flags'?
+                ModelInfoValueFlag infoHasModelIndex = this.info.Flags & (ModelInfoValueFlag)~(UInt32)0x003C0000; // what did we get told in 'info'?
+                if (flagsHasModelIndex == 0 && infoHasModelIndex != 0) // we have an inconsistent state
+                    this.flags |= ModelInfoValueFlag.hasModelIndex19; // arbitrary flag just to make it consistent, rather than throw away 'info' value
+                else if (flagsHasModelIndex != 0 && infoHasModelIndex == 0) // we have an inconsistent state
+                    this.flags &= (ModelInfoValueFlag)~(UInt32)0x003C0000; // clear all the flags as we have no 'info' value
+                
+                // Moving on... We can just clear the remaining flags for which we may have 'info' values and set them again if we have
+                this.flags &= (ModelInfoValueFlag)~(UInt32)0xC3000000;
+                this.flags |= this.info.Flags & (ModelInfoValueFlag)~(UInt32)0x003C0000;
+
+                // Now expose this to the parent
+                base.serializationID = ((UInt32)this.flags | (UInt32)this.data.Count);
+            }
+            public ThumbnailDataModelObject(int APIversion, EventHandler handler, Stream s, UInt32 serializationID) : base(APIversion, handler, serializationID) { Parse(s); }
+            #endregion
+
+            #region Data I/O
+            public void Parse(Stream s)
+            {
+                BinaryReader r = new BinaryReader(s);
+
+                this.flags = (ModelInfoValueFlag)(serializationID & 0xFFFF0000);
+                this.data = new ModelDataList(handler, s, (UInt16)(serializationID & 0xFFFF));
+
+                this.info = new ModelInfoDict(handler);
+                if ((flags & ModelInfoValueFlag.hasPaintingKey32) != 0) info[ModelInfoValueFlag.hasPaintingKey32] = new ModelInfoValueUInt64(requestedApiVersion, handler, r.ReadUInt64());
+                if ((flags & ModelInfoValueFlag.hasPaintingGroup25) != 0) info[ModelInfoValueFlag.hasPaintingGroup25] = new ModelInfoValueUInt32(requestedApiVersion, handler, r.ReadUInt32());
+                if ((flags & ModelInfoValueFlag.hasGeoState31) != 0) info[ModelInfoValueFlag.hasGeoState31] = new ModelInfoValueUInt32(requestedApiVersion, handler, r.ReadUInt32());
+                if ((flags & ModelInfoValueFlag.hasMaterialState26) != 0) info[ModelInfoValueFlag.hasMaterialState26] = new ModelInfoValueUInt32(requestedApiVersion, handler, r.ReadUInt32());
+
+                // hasModelIndex is not so simple, of course.  We will take the lowest order bit...
+                for (UInt32 i = (UInt32)ModelInfoValueFlag.hasModelIndex19, j = 0; ((UInt32)flags & 0x003C0000) != 0 && j < 4; i <<= 1, j++)
+                    if (((UInt32)flags & i) != 0)
+                    {
+                        info[(ModelInfoValueFlag)i] = new ModelInfoValueByte(requestedApiVersion, handler, r.ReadByte());
+                        break;
+                    }
+            }
+
+            public override void UnParse(Stream s)
+            {
+                BinaryWriter w = new BinaryWriter(s);
+
+                // Make sure things are sane again... same as constructor
+                ModelInfoValueFlag flagsHasModelIndex = this.flags & (ModelInfoValueFlag)~(UInt32)0x003C0000;
+                ModelInfoValueFlag infoHasModelIndex = this.info.Flags & (ModelInfoValueFlag)~(UInt32)0x003C0000;
+                if (flagsHasModelIndex == 0 && infoHasModelIndex != 0) // we have an inconsistent state
+                    this.flags |= ModelInfoValueFlag.hasModelIndex19;
+                else if (flagsHasModelIndex != 0 && infoHasModelIndex == 0) // we have an inconsistent state
+                    this.flags &= (ModelInfoValueFlag)~(UInt32)0x003C0000;
+
+                this.flags &= (ModelInfoValueFlag)~0xC3000000;
+                this.flags |= (this.info.Flags & (ModelInfoValueFlag)~(UInt32)0x003C0000);
+
+                base.serializationID = ((UInt32)this.flags | (UInt32)this.data.Count);
+
+                base.UnParse(s);
+                this.data.UnParse(s);
+                if ((flags & ModelInfoValueFlag.hasPaintingKey32) != 0) info[ModelInfoValueFlag.hasPaintingKey32].UnParse(s);
+                if ((flags & ModelInfoValueFlag.hasPaintingGroup25) != 0) info[ModelInfoValueFlag.hasPaintingGroup25].UnParse(s);
+                if ((flags & ModelInfoValueFlag.hasGeoState31) != 0) info[ModelInfoValueFlag.hasGeoState31].UnParse(s);
+                if ((flags & ModelInfoValueFlag.hasMaterialState26) != 0) info[ModelInfoValueFlag.hasMaterialState26].UnParse(s);
+
+                for (UInt32 i = (UInt32)ModelInfoValueFlag.hasModelIndex19, j = 0; ((UInt32)flags & 0x003C0000) != 0 && j < 4; i <<= 1, j++)
+                    if (((UInt32)flags & i) != 0)
+                    {
+                        info[(ModelInfoValueFlag)i].UnParse(s);
+                        break;
+                    }
+            }
+            #endregion
+
+            #region AHandlerElement Members
+            public override int RecommendedApiVersion { get { return recommendedApiVersion; } }
+            public override List<string> ContentFields
+            {
+                get
+                {
+                    List<String> contentFields = GetContentFields(requestedApiVersion, this.GetType());
+                    contentFields.Remove("ThumbnailDataType");
+                    return contentFields;
+                }
+            }
+            #endregion
+
+            #region IEquatable<ThumbnailDataModelObject> Members
+
+            public bool Equals(ThumbnailDataModelObject other)
+            {
+                return base.Equals((ThumbnailData)other)
+                    && data.Equals(other.data)
+                    && info.Equals(other.info)
+                    ;
+            }
+
+            public override bool Equals(ThumbnailData obj)
+            {
+                return obj as ThumbnailDataModelObject != null ? this.Equals(obj as ThumbnailDataModelObject) : false;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj as ThumbnailDataModelObject != null ? this.Equals(obj as ThumbnailDataModelObject) : false;
+            }
+
+            public override int GetHashCode()
+            {
+                return base.GetHashCode()
+                    ^ data.GetHashCode()
+                    ^ info.GetHashCode()
+                    ;
+            }
+
+            #endregion
+
+            #region Content Fields
+            [MinimumVersion(1)]
+            [MaximumVersion(recommendedApiVersion)]
+            [ElementPriority(1)]
+            public ModelDataList Data { get { return data; } set { if (!data.Equals(value)) { data = value == null ? null : new ModelDataList(handler, value); OnElementChanged(); } } }
+            [ElementPriority(1)]
+            public ModelInfoDict Info { get { return info; } set { if (!info.Equals(value)) { info = value == null ? null : new ModelInfoDict(handler, value); OnElementChanged(); } } }
+            #endregion
+        }
+
+        public class ThumbnailDataList : DependentList<ThumbnailData>
+        {
+            ThumbnailType type;
+
+            #region Constructors
+            public ThumbnailDataList(EventHandler handler, ThumbnailType type) : base(handler, 1) { this.type = type; }
+            public ThumbnailDataList(EventHandler handler, Stream s, ThumbnailType type) : this(null, type) { this.elementHandler = handler; this.Parse(s); this.handler = handler; }
+            public ThumbnailDataList(EventHandler handler, IEnumerable<ThumbnailData> llp, ThumbnailType type) : this(null, type) { this.elementHandler = handler; foreach (var t in llp) this.Add((ThumbnailData)t.Clone(null)); this.handler = handler; }
+            #endregion
+
+            #region Data I/O
+            protected override int ReadCount(Stream s) { return (new BinaryReader(s)).ReadByte() == 0 ? 0 : 1; }
+            protected override void WriteCount(Stream s, int count)
+            {
+                if (count != 0 && count != 1)
+                    throw new InvalidOperationException(String.Format("TableEntryDataList should only ever have zero or one entries.  Found {0}.", count));
+                (new BinaryWriter(s)).Write((Byte)count);
+            }
+            protected override ThumbnailData CreateElement(Stream s)
+            {
+                return ThumbnailData.Factory(0, elementHandler, s, type);
+            }
+            protected override void WriteElement(Stream s, ThumbnailData element) { element.UnParse(s); }
+            #endregion
+        }
+
+        public class Thumnail : AHandlerElement, IEquatable<Thumnail>
+        {
+            #region Attributes
+            ThumbnailType type;
+            ThumbnailSize size;
+            UInt32 versionType;
+            UInt64 resourceID;
+            UInt32 index;
+            ThumbnailDataList data;
+            TGIBlock resourceKey;
+            Boolean isAlias;
+            #endregion
+
+            #region Constructors
+            public Thumnail(int apiVersion, EventHandler handler)
+                : this(apiVersion, handler,
+                ThumbnailType.OBJECT, ThumbnailSize.SMALL, 0, 0, 0, new ThumbnailDataList(null, ThumbnailType.OBJECT), new TGIBlock(apiVersion, null), false) { }
+            public Thumnail(int apiVersion, EventHandler handler, Thumnail basis)
+                : this(apiVersion, handler,
+                basis.type, basis.size, basis.versionType, basis.resourceID, basis.index, basis.data, basis.resourceKey, basis.isAlias) { }
+            public Thumnail(int apiVersion, EventHandler handler,
+                ThumbnailType type, ThumbnailSize size, UInt32 versionType, UInt64 resourceID, UInt32 index, IEnumerable<ThumbnailData> data, TGIBlock resourceKey, Boolean isAlias)
+                : base(apiVersion, handler)
+            {
+                this.type = type;
+                this.size = size;
+                this.versionType = versionType;
+                this.resourceID = resourceID;
+                this.index = index;
+                this.data = new ThumbnailDataList(handler, data, type);
+                this.resourceKey = new TGIBlock(apiVersion, handler, resourceKey);
+                this.isAlias = isAlias;
+            }
+            public Thumnail(int APIversion, EventHandler handler, Stream s) : base(APIversion, handler) { Parse(s); }
+            #endregion
+
+            #region Data I/O
+            public void Parse(Stream s)
+            {
+                BinaryReader r = new BinaryReader(s);
+
+                this.type = (ThumbnailType)r.ReadUInt32();
+                this.size = (ThumbnailSize)r.ReadUInt32();
+                this.versionType = r.ReadUInt32();
+                this.resourceID = r.ReadUInt64();
+                this.index = r.ReadUInt32();
+                this.data = new ThumbnailDataList(handler, s, type);
+                this.resourceKey = new TGIBlock(this.requestedApiVersion, handler, s);
+                this.isAlias = r.ReadByte() != 0;
+            }
+
+            internal void UnParse(Stream s)
+            {
+                BinaryWriter w = new BinaryWriter(s);
+
+                w.Write((UInt32)type);
+                w.Write((UInt32)size);
+                w.Write(versionType);
+                w.Write(resourceID);
+                w.Write(index);
+                data.UnParse(s);
+                resourceKey.UnParse(s);
+                w.Write((Byte)(isAlias ? 1 : 0));
+            }
+            #endregion
+
+            #region AHandlerElement Members
+            public override int RecommendedApiVersion { get { return recommendedApiVersion; } }
+            public override List<string> ContentFields { get { return GetContentFields(requestedApiVersion, this.GetType()); } }
+            #endregion
+
+            #region IEquatable<TableEntry> Members
+
+            public bool Equals(Thumnail other)
+            {
+                return type.Equals(other.type)
+                    && size.Equals(other.size)
+                    && versionType.Equals(other.versionType)
+                    && resourceID.Equals(other.resourceID)
+                    && index.Equals(other.index)
+                    && data.Equals(other.data)
+                    && resourceKey.Equals(other.resourceKey)
+                    && isAlias.Equals(other.isAlias)
+                    ;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj as Thumnail != null ? this.Equals(obj as Thumnail) : false;
+            }
+
+            public override int GetHashCode()
+            {
+                return type.GetHashCode()
+                    ^ size.GetHashCode()
+                    ^ versionType.GetHashCode()
+                    ^ resourceID.GetHashCode()
+                    ^ index.GetHashCode()
+                    ^ data.GetHashCode()
+                    ^ resourceKey.GetHashCode()
+                    ^ isAlias.GetHashCode()
+                    ;
+            }
+
+            #endregion
+
+            #region Content Fields
+            [MinimumVersion(1)]
+            [MaximumVersion(recommendedApiVersion)]
+            [ElementPriority(1)]
+            public ThumbnailType ThumbType { get { return type; } set { if (type != value) { type = value; OnElementChanged(); } } }
+            [ElementPriority(2)]
+            public ThumbnailSize ThumbSize { get { return size; } set { if (size != value) { size = value; OnElementChanged(); } } }
+            [ElementPriority(3)]
+            public UInt32 VersionType { get { return versionType; } set { if (versionType != value) { versionType = value; OnElementChanged(); } } }
+            [ElementPriority(4)]
+            public UInt64 ResourceID { get { return resourceID; } set { if (resourceID != value) { resourceID = value; OnElementChanged(); } } }
+            [ElementPriority(5)]
+            public UInt32 Index { get { return index; } set { if (index != value) { index = value; OnElementChanged(); } } }
+            [ElementPriority(6)]
+            public ThumbnailDataList ThumbData { get { return data; } set { if (!data.Equals(value)) { data = value == null ? null : new ThumbnailDataList(handler, value, type); OnElementChanged(); } } }
+            [ElementPriority(7)]
+            public TGIBlock ResourceKey { get { return resourceKey; } set { if (!resourceKey.Equals(value)) { resourceKey = value == null ? null : new TGIBlock(requestedApiVersion, handler, value); OnElementChanged(); } } }
+            [ElementPriority(8)]
+            public Boolean ObjectId { get { return isAlias; } set { if (isAlias != value) { isAlias = value; OnElementChanged(); } } }
+            #endregion
+
+            public string Value { get { return ValueBuilder; } }
+        }
+        public class ThumnailList : DependentList<Thumnail>
+        {
+            #region Constructors
+            public ThumnailList(EventHandler handler) : base(handler) { }
+            public ThumnailList(EventHandler handler, Stream s) : base(handler, s) { }
+            public ThumnailList(EventHandler handler, IEnumerable<Thumnail> llp) : base(handler, llp) { }
+            #endregion
+
+            #region Data I/O
+            protected override Thumnail CreateElement(Stream s) { return new Thumnail(0, elementHandler, s); }
+            protected override void WriteElement(Stream s, Thumnail element) { element.UnParse(s); }
+            #endregion
+        }
+        #endregion
+
+        #region Content Fields
+        [MinimumVersion(1)]
+        [MaximumVersion(recommendedApiVersion)]
+        [ElementPriority(1)]
+        public UInt32 Version { get { return version; } set { if (version != value) { version = value; OnResourceChanged(this, EventArgs.Empty); } } }
+        [ElementPriority(2)]
+        public UInt64 NextInstanceValue { get { return nextInstanceValue; } set { if (nextInstanceValue != value) { nextInstanceValue = value; OnResourceChanged(this, EventArgs.Empty); } } }
+        [ElementPriority(3)]
+        public ThumnailList Thumnails { get { return thumbnails; } set { if (!thumbnails.Equals(value)) { thumbnails = value == null ? null : new ThumnailList(OnResourceChanged, value); OnResourceChanged(this, EventArgs.Empty); } } }
+        #endregion
+
+        public string Value { get { return this.ValueBuilder; } }
+    }
+
+    public class ThumbnailCacheResourceHandler : AResourceHandler
+    {
+        /// <summary>
+        /// Create the content of the Dictionary.
+        /// </summary>
+        public ThumbnailCacheResourceHandler()
+        {
+            this.Add(typeof(ThumbnailCacheResource), new List<string>(new string[] { "0xB93A9915", }));
+        }
+    }
+}

--- a/s4pi Wrappers/ThumbnailCacheTableResource/ThumbnailCacheResource.csproj
+++ b/s4pi Wrappers/ThumbnailCacheTableResource/ThumbnailCacheResource.csproj
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B8796317-C2C8-4315-9F4F-0130DD78646B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ThumbnailCacheResource</RootNamespace>
+    <AssemblyName>s4pi.ThumbnailCacheResource</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ThumbnailCacheResource.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\CS System Classes\CS System Classes.csproj">
+      <Project>{00200e76-c245-42a7-b567-5c30edbce977}</Project>
+      <Name>CS System Classes</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\s4pi\Interfaces\Interfaces.csproj">
+      <Project>{51023bd2-9139-438d-b794-95e5ec023537}</Project>
+      <Name>Interfaces</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\s4pi\Settings\Settings.csproj">
+      <Project>{374f37cf-1f27-4613-96fd-9b956a3d82b1}</Project>
+      <Name>Settings</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>"$(SolutionDir)s4pi\CreateAssemblyVersion\bin\Debug\CreateAssemblyVersion" "$(ProjectDir)\"</PreBuildEvent>
+  </PropertyGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/s4pi Wrappers/s4piRCOLChunks/KDTree.cs
+++ b/s4pi Wrappers/s4piRCOLChunks/KDTree.cs
@@ -393,7 +393,7 @@ namespace s4pi.GenericRCOLResource
             #region Constructors
             public CountedUInt16List(EventHandler handler) : base(handler, ReadUInt16, WriteUInt16) { }
             public CountedUInt16List(EventHandler handler, IEnumerable<UInt16> basis) : base(handler, basis, ReadUInt16, WriteUInt16) { }
-            public CountedUInt16List(EventHandler handler, Stream s, UInt32 indexCount) : base(handler, s, ReadUInt16, WriteUInt16) { }
+            public CountedUInt16List(EventHandler handler, Stream s, UInt32 indexCount) : base(handler, ReadUInt16, WriteUInt16) { this.indexCount = indexCount; elementHandler = handler; Parse(s); this.handler = handler; }
             #endregion
 
             #region Data I/O

--- a/s4pi Wrappers/s4piRCOLChunks/LITE.cs
+++ b/s4pi Wrappers/s4piRCOLChunks/LITE.cs
@@ -398,8 +398,6 @@ namespace s4pi.GenericRCOLResource
                     }
                 }
                 #endregion
-
-                public string Value { get { return ValueBuilder; } }
             }
 
             public class SpotLightSourceType : AbstractLightSourceType
@@ -496,8 +494,6 @@ namespace s4pi.GenericRCOLResource
                     }
                 }
                 #endregion
-
-                public string Value { get { return ValueBuilder; } }
             }
 
             public class LampShadeLightSourceType : AbstractLightSourceType
@@ -614,8 +610,6 @@ namespace s4pi.GenericRCOLResource
                     }
                 }
                 #endregion
-
-                public string Value { get { return ValueBuilder; } }
             }
 
             public class TubeLightSourceType : AbstractLightSourceType
@@ -712,8 +706,6 @@ namespace s4pi.GenericRCOLResource
                     }
                 }
                 #endregion
-
-                public string Value { get { return ValueBuilder; } }
             }
 
             public class SquareWindowLightSourceType : AbstractLightSourceType
@@ -840,8 +832,6 @@ namespace s4pi.GenericRCOLResource
                     }
                 }
                 #endregion
-
-                public string Value { get { return ValueBuilder; } }
             }
 
             public class CircularWindowLightSourceType : AbstractLightSourceType
@@ -938,8 +928,6 @@ namespace s4pi.GenericRCOLResource
                     }
                 }
                 #endregion
-
-                public string Value { get { return ValueBuilder; } }
             }
             #endregion
 

--- a/s4pi Wrappers/s4piRCOLChunks/WMAP.cs
+++ b/s4pi Wrappers/s4piRCOLChunks/WMAP.cs
@@ -225,8 +225,6 @@ namespace s4pi.GenericRCOLResource
 
         public class LotInfoList : DependentList<LotInfoElement>
         {
-            int count;
-
             #region Constructors
             public LotInfoList(EventHandler handler) : base(handler) { }
             public LotInfoList(EventHandler handler, Stream s) : base(handler, s) { }

--- a/s4pi/Interfaces/DependentDictionary.cs
+++ b/s4pi/Interfaces/DependentDictionary.cs
@@ -87,7 +87,6 @@ namespace s4pi.Interfaces
 		/// </summary>
 		/// <param name="handler">The <see cref="EventHandler" /> to call on changes to the list or its elements.</param>
 		/// <param name="s">The <see cref="System.IO.Stream" /> to read for the initial content of the list.</param>
-		/// <param name="maxSize">Optional; -1 for unlimited size, otherwise the maximum number of elements in the list.</param>
 		/// <exception cref="System.InvalidOperationException">Thrown when list size exceeded.</exception>
         protected DependentDictionary(EventHandler handler, Stream s)
 			: base(null)
@@ -105,7 +104,7 @@ namespace s4pi.Interfaces
         ///     Read list entries from a stream
         /// </summary>
         /// <param name="s">Stream containing list entries</param>
-        /// <remarks>This method bypasses <see cref="DependentList{T}.Add(object[])"/> because
+        /// <remarks>This method bypasses <see cref="DependentDictionary{TKey, TValue}.Add(TKey, TValue)"/> because
         /// <see cref="CreateKey(Stream, out bool)"/> and <see cref="CreateValue(Stream, out bool)"/>
         /// must take care of the same issues.</remarks>
         protected virtual void Parse(Stream s)
@@ -197,14 +196,14 @@ namespace s4pi.Interfaces
         /// <summary>
         ///     Write a key to the stream.
         /// </summary>
-        /// <param name="s"><see cref="System.IO.Stream" /> to write <paramref name="element" /> to.</param>
+        /// <param name="s"><see cref="System.IO.Stream" /> to write <paramref name="key" /> to.</param>
         /// <param name="key">The key to write to <see cref="System.IO.Stream" /> <paramref name="s" />.</param>
         protected abstract void WriteKey(Stream s, TKey key);
 
         /// <summary>
         ///     Write a value to the stream.
         /// </summary>
-        /// <param name="s"><see cref="System.IO.Stream" /> to write <paramref name="element" /> to.</param>
+        /// <param name="s"><see cref="System.IO.Stream" /> to write <paramref name="value" /> to.</param>
         /// <param name="value">The value to write to <see cref="System.IO.Stream" /> <paramref name="s" />.</param>
         protected abstract void WriteValue(Stream s, TValue value);
 
@@ -268,7 +267,7 @@ namespace s4pi.Interfaces
         }
 
         /// <summary>
-        ///     Adds an entry to a <see cref="DependentDictionary{T}" />, setting the element change handler.
+        ///     Adds an entry to a <see cref="DependentDictionary{TKey, TValue}" />, setting the element change handler.
         /// </summary>
         /// <param name="key">The key of the element to add.</param>
         /// <param name="value">An instance of type <c>{TValue}</c> to add to the list.</param>
@@ -285,7 +284,7 @@ namespace s4pi.Interfaces
         ///     The dictionary change handler will only be called once for the collection.
         /// </summary>
         /// <param name="collection">A collection of <see cref="KeyValuePair{TKey, TValue}" /> items to add.</param>
-        /// <exception cref="System.ArgumentNullException"><paramref name="key"/> is null in one of the items in the collection.</exception>
+        /// <exception cref="System.ArgumentNullException"><paramref name="collection"/> is null or the key of one of the items in the collection is null.</exception>
         /// <exception cref="System.ArgumentException">An element with the same key already exists in the <see cref="AHandlerDictionary{TKey,TValue}"/>.</exception>
         public virtual void AddRange(IEnumerable<KeyValuePair<TKey, TValue>> collection)
         {
@@ -306,6 +305,13 @@ namespace s4pi.Interfaces
     
     }
 
+    /// <summary>
+    /// A flexible generic list that implements <see cref="DependentDictionary{TKey, TValue}"/> for
+    /// a simple value data type (such as <see cref="UInt32"/>).
+    /// </summary>
+    /// <typeparam name="TKey">The type of the keys in the dictionary.</typeparam>
+    /// <typeparam name="TValue">A simple data type (such as <see cref="UInt32"/>).</typeparam>
+    /// <seealso cref="HandlerElement{T}"/>
     public abstract class SimpleDictionary<TKey, TValue> : DependentDictionary<TKey, HandlerElement<TValue>>, IDictionary<TKey, HandlerElement<TValue>>
         where TValue : struct, IComparable, IConvertible, IEquatable<TValue>, IComparable<TValue>
     {
@@ -314,7 +320,6 @@ namespace s4pi.Interfaces
         WriteValueMethod writeValue;
         ReadCountMethod readCount;
         WriteCountMethod writeCount;
-        private SimpleDictionary<ulong, float> dictionary;
         #endregion
 
         #region Constructors
@@ -436,7 +441,7 @@ namespace s4pi.Interfaces
         ///     Add a default element to a <see cref="SimpleDictionary{TKey, TValue}" />.
         /// </summary>
         /// <param name="key">The key of the element to add.</param>
-        /// <exception cref="NotImplementedException"><typeparamref name="T" /> is abstract.</exception>
+        /// <exception cref="NotImplementedException"><typeparamref name="TKey" /> is abstract.</exception>
         /// <exception cref="InvalidOperationException">Thrown when list size exceeded.</exception>
         /// <exception cref="NotSupportedException">The <see cref="DependentList{T}" /> is read-only.</exception>
         public override void Add(TKey key)
@@ -458,7 +463,7 @@ namespace s4pi.Interfaces
         ///     The dictionary change handler will only be called once for the collection.
         /// </summary>
         /// <param name="collection">A collection of <see cref="KeyValuePair{TKey, TValue}" /> items to add.</param>
-        /// <exception cref="System.ArgumentNullException"><paramref name="key"/> is null in one of the items in the collection.</exception>
+        /// <exception cref="System.ArgumentNullException"><paramref name="collection"/> is null or one of the items in the collection is null.</exception>
         /// <exception cref="System.ArgumentException">An element with the same key already exists in the <see cref="AHandlerDictionary{TKey,TValue}"/>.</exception>
         public virtual void AddRange(IEnumerable<KeyValuePair<TKey, TValue>> collection)
         {

--- a/s4pi/Interfaces/DependentList.cs
+++ b/s4pi/Interfaces/DependentList.cs
@@ -103,7 +103,7 @@ namespace s4pi.Interfaces
 		///     Read list entries from a stream
 		/// </summary>
 		/// <param name="s">Stream containing list entries</param>
-		/// <remarks>This method bypasses <see cref="DependentList{T}.Add(object[])"/>
+		/// <remarks>This method bypasses <see cref="DependentList{T}.Add(T)"/>
 		/// because <see cref="CreateElement(Stream, out bool)"/> must take care of the same issues.</remarks>
 		protected virtual void Parse(Stream s)
 		{

--- a/s4pi/Interfaces/IWrapperCloneable.cs
+++ b/s4pi/Interfaces/IWrapperCloneable.cs
@@ -16,6 +16,7 @@ namespace s4pi.Interfaces
         /// </summary>
         /// <param name="hashsalt">Hash salt to renumber the fields</param>
         /// <param name="renumber">If true, preset fields will be renumbered</param>
+        /// <param name="isStandAlone">Unused, like the whole of this interface, by the look of it.</param>
         /// <returns>T</returns>
         T CloneWrapper(string hashsalt, bool renumber = true, bool isStandAlone = true);
     }

--- a/s4pi/buildAll/buildAll.csproj
+++ b/s4pi/buildAll/buildAll.csproj
@@ -80,11 +80,6 @@
       <Project>{00200E76-C245-42A7-B567-5C30EDBCE977}</Project>
       <Name>CS System Classes</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\s4pe Helpers\ModelViewer\ModelViewer.csproj">
-      <Project>{d31e7fc7-e51d-40e4-b2fb-49de645291e5}</Project>
-      <Name>ModelViewer</Name>
-      <Private>False</Private>
-    </ProjectReference>
     <ProjectReference Include="..\..\s4pi Wrappers\AnimationResources\AnimationResources.csproj">
       <Project>{b33f19de-f211-4d32-8d03-43024b88f177}</Project>
       <Name>AnimationResources</Name>

--- a/sims4tools.sln
+++ b/sims4tools.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Express 2013 for Windows Desktop
-VisualStudioVersion = 12.0.30723.0
+VisualStudioVersion = 12.0.40629.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CreateAssemblyVersion", "s4pi\CreateAssemblyVersion\CreateAssemblyVersion.csproj", "{114622FB-D6BF-4EA7-9BB9-FB06B5A01212}"
 EndProject
@@ -67,6 +67,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "s4pe", "s4pe\s4pe.csproj", 
 		{F2E30D04-82C7-487F-B9E8-E8BABB1C94E1} = {F2E30D04-82C7-487F-B9E8-E8BABB1C94E1}
 		{DA02A213-A2D9-422B-9214-51B86378CFBB} = {DA02A213-A2D9-422B-9214-51B86378CFBB}
 		{F4E52414-B7CC-4920-9546-0711D5A1F4C9} = {F4E52414-B7CC-4920-9546-0711D5A1F4C9}
+		{B8796317-C2C8-4315-9F4F-0130DD78646B} = {B8796317-C2C8-4315-9F4F-0130DD78646B}
 		{3D2A241B-533B-47B5-A8D1-DB3B7953E6A7} = {3D2A241B-533B-47B5-A8D1-DB3B7953E6A7}
 		{513B8C1F-2BE4-46D6-B95D-836A1F36855E} = {513B8C1F-2BE4-46D6-B95D-836A1F36855E}
 		{E8176722-BE4E-47FF-A8A6-BFF4BE7A5DE8} = {E8176722-BE4E-47FF-A8A6-BFF4BE7A5DE8}
@@ -138,6 +139,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RegionDescriptionResource", "s4pi Wrappers\RegionDescriptionResource\RegionDescriptionResource.csproj", "{03C47845-A16F-492F-B06F-9D6622E13374}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TerrainBlendMapResource", "s4pi Wrappers\TerrainBlendMapResource\TerrainBlendMapResource.csproj", "{ABE6CF97-3F4D-4F2C-8A9C-B09491CB5843}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ThumbnailCacheResource", "s4pi Wrappers\ThumbnailCacheTableResource\ThumbnailCacheResource.csproj", "{B8796317-C2C8-4315-9F4F-0130DD78646B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -619,6 +622,16 @@ Global
 		{ABE6CF97-3F4D-4F2C-8A9C-B09491CB5843}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{ABE6CF97-3F4D-4F2C-8A9C-B09491CB5843}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{ABE6CF97-3F4D-4F2C-8A9C-B09491CB5843}.Release|x86.ActiveCfg = Release|Any CPU
+		{B8796317-C2C8-4315-9F4F-0130DD78646B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B8796317-C2C8-4315-9F4F-0130DD78646B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B8796317-C2C8-4315-9F4F-0130DD78646B}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{B8796317-C2C8-4315-9F4F-0130DD78646B}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{B8796317-C2C8-4315-9F4F-0130DD78646B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B8796317-C2C8-4315-9F4F-0130DD78646B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B8796317-C2C8-4315-9F4F-0130DD78646B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B8796317-C2C8-4315-9F4F-0130DD78646B}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{B8796317-C2C8-4315-9F4F-0130DD78646B}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{B8796317-C2C8-4315-9F4F-0130DD78646B}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Whole load of fix ups I spotted whilst getting the Thumbnail Cache Table resource wrapper written.

Unfortunately, it looks like we've got version 6 of the BT file for that and the current version is version 7, so that's another for the list of new versions required.